### PR TITLE
Set a default ecuIdentifiers and hardwareID for targets metadata.

### DIFF
--- a/tuf_vectors/step.py
+++ b/tuf_vectors/step.py
@@ -325,6 +325,13 @@ class Step(Generator):
                 'hashes': {
                     'sha256': sha256(content, bad_hash=bad_hash),
                     'sha512': sha512(content, bad_hash=bad_hash),
+                },
+                'custom' : {
+                    'ecuIdentifiers' : {
+                        'test_primary_ecu_serial' : {
+                            'hardwareId' : 'test_primary_hardware_id',
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
This is necessary for aktualizr now that it properly checks for these items.