### PR TITLE
Add explicit Jinja2 version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,7 @@ setup(
     author="heartsucker",
     author_email="heartsucker@autistici.org",
     description="Generates TUF/Uptane test vectors",
+    install_requires=[
+        'Jinja2>=2.10.1',
+    ],
 )


### PR DESCRIPTION
This prevents us from having insecure implicit Jinja2 dependency. Corresponding
upstream fix for flask is in https://github.com/pallets/flask/pull/3155