### PR TITLE
Do not run the app in debug mode by default

### DIFF
--- a/server.py
+++ b/server.py
@@ -19,7 +19,7 @@ def main():
         cjson_strategy=args.cjson,
         ecu_identifier=args.ecu_identifier,
         hardware_id=args.hardware_id)
-    app.run(host=args.host, port=args.port, debug=True)
+    app.run(host=args.host, port=args.port, debug=args.debug)
 
 
 def arg_parser():
@@ -29,6 +29,8 @@ def arg_parser():
                         default='127.0.0.1')
     parser.add_argument('-P', '--port', help='The port to bind the app to',
                         type=int, default=8080)
+    parser.add_argument('--debug', help='Run the server in debug mode',
+                        action='store_true')
 
     parser.add_argument('--signature-encoding', help='The encoding for cryptographic signatures',
                         default='hex', choices=['hex', 'base64'])


### PR DESCRIPTION
This is not needed for running the suite and could have some unexpected implications (posed problems in the past).

Still leave it accessible through the command line, just in case!