### PR TITLE
More correctly fetch root with prefixed version.

### DIFF
--- a/ci/gitlab/.gitlab-ci.yml
+++ b/ci/gitlab/.gitlab-ci.yml
@@ -9,9 +9,6 @@ variables:
 Docker Setup:
   image: docker:18
   stage: docker
-  except:
-    - /^20\d\d\.\d\d?-docs$/
-    - /^docs\//
   services:
     - docker:18-dind
   before_script:
@@ -27,9 +24,6 @@ Docker Setup:
 tuf-test-vector:
   image: "$UBUNTU_BIONIC_PR_IMAGE"
   stage: test
-  except:
-    - /^20\d\d\.\d\d?-docs$/
-    - /^docs\//
   script:
     - make lint
     - make test

--- a/tuf_vectors/metadata.py
+++ b/tuf_vectors/metadata.py
@@ -278,10 +278,13 @@ class Root(Metadata):
             targets_bad_key_ids: list = None,
             snapshot_bad_key_ids: list = None,
             timestamp_bad_key_ids: list = None,
+            stated_version: int = None,
             **kwargs) -> None:
         super().__init__(is_delegation=False, **kwargs)
         self.role_name = 'root'
         self.version = version
+        if stated_version is None:
+            stated_version = version
 
         if root_sign_keys_idx is None:
             root_sign_keys_idx = root_keys_idx
@@ -307,7 +310,7 @@ class Root(Metadata):
 
         signed = {
             '_type': kwargs.get('_type', 'Root'),
-            'version': version,
+            'version': stated_version,
             'expires': '2017-01-01T00:00:00Z' if is_expired else '2038-01-19T03:14:06Z',
             'consistent_snapshot': False,
             'keys': {},

--- a/tuf_vectors/metadata.py
+++ b/tuf_vectors/metadata.py
@@ -250,6 +250,8 @@ class Metadata(Helper):
     def persist(self) -> None:
         if self.is_delegation:
             full_path = path.join(self.output_dir, self.uptane_role, 'delegations', self.role_name + '.json')
+        elif self.role_name == 'root':
+            full_path = path.join(self.output_dir, self.uptane_role, str(self.version) + '.' + self.role_name + '.json')
         else:
             full_path = path.join(self.output_dir, self.uptane_role, self.role_name + '.json')
         os.makedirs(path.dirname(full_path), exist_ok=True)
@@ -277,8 +279,9 @@ class Root(Metadata):
             snapshot_bad_key_ids: list = None,
             timestamp_bad_key_ids: list = None,
             **kwargs) -> None:
-        self.role_name = 'root'
         super().__init__(is_delegation=False, **kwargs)
+        self.role_name = 'root'
+        self.version = version
 
         if root_sign_keys_idx is None:
             root_sign_keys_idx = root_keys_idx

--- a/tuf_vectors/server.py
+++ b/tuf_vectors/server.py
@@ -86,7 +86,7 @@ def init_app(
 
         # Assume root version must be equal to or less than current step.
         if current < root_version:
-            return abort(404)
+            abort(404)
 
         repo = repos.get(repo, None)
         if repo is None:
@@ -107,7 +107,7 @@ def init_app(
 
         # Make sure the version we've fetched is matches the version requested.
         if step_repo.root.version != root_version:
-            return abort(404)
+            abort(404)
 
         return jsonify(step_repo.root.value)
 

--- a/tuf_vectors/uptane.py
+++ b/tuf_vectors/uptane.py
@@ -2639,6 +2639,302 @@ class ImageRepoRootRotationNoNewSignatureUptane(Uptane):
     ]
 
 
+class DirectorRootRotationVersionUnchangedUptane(Uptane):
+
+    '''Director step 0 has root v1, step 1 has root v2, and it is correctly cross signed,
+       but the version is unchanged. The standard accepts this but we do not.'''
+
+    class ImageStep(Step):
+
+        TARGETS_KEYS_IDX = [1]
+        SNAPSHOT_KEYS_IDX = [2]
+        TIMESTAMP_KEYS_IDX = [3]
+
+        ROOT_KWARGS = {
+            'root_keys_idx': [0],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        SNAPSHOT_KWARGS = {
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+        }
+
+        TIMESTAMP_KWARGS = {
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+    class DirectorStep1(Step):
+
+        TARGETS_KEYS_IDX = [5]
+
+        ROOT_KWARGS = {
+            'root_keys_idx': [4],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+    class DirectorStep2(Step):
+
+        # Note that aktualizr doesn't actually throw an exception; it just fails.
+        UPDATE_ERROR = 'UnmetThreshold::Root'
+
+        TARGETS_KEYS_IDX = [5]
+
+        ROOT_KWARGS = {
+            'version': 2,
+            'root_keys_idx': [6],
+            'root_sign_keys_idx': [4, 6],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'stated_version': 1,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+    STEPS = [
+        (DirectorStep1, ImageStep),
+        (DirectorStep2, ImageStep),
+    ]
+
+
+class ImageRepoRootRotationVersionUnchangedUptane(Uptane):
+
+    '''Image repo step 0 has root v1, step 1 has root v2, and it is correctly cross signed,
+       but the version is unchanged. The standard accepts this but we do not.'''
+
+    class ImageStep1(Step):
+
+        TARGETS_KEYS_IDX = [1]
+        SNAPSHOT_KEYS_IDX = [2]
+        TIMESTAMP_KEYS_IDX = [3]
+
+        ROOT_KWARGS = {
+            'root_keys_idx': [0],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        SNAPSHOT_KWARGS = {
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+        }
+
+        TIMESTAMP_KWARGS = {
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+    class ImageStep2(Step):
+
+        # Note that aktualizr doesn't actually throw an exception; it just fails.
+        UPDATE_ERROR = 'UnmetThreshold::Root'
+
+        TARGETS_KEYS_IDX = [1]
+        SNAPSHOT_KEYS_IDX = [2]
+        TIMESTAMP_KEYS_IDX = [3]
+
+        ROOT_KWARGS = {
+            'version': 2,
+            'root_keys_idx': [6],
+            'root_sign_keys_idx': [0, 6],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+            'stated_version': 1,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        SNAPSHOT_KWARGS = {
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+        }
+
+        TIMESTAMP_KWARGS = {
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+    class DirectorStep(Step):
+
+        TARGETS_KEYS_IDX = [5]
+
+        ROOT_KWARGS = {
+            'root_keys_idx': [4],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+    STEPS = [
+        (DirectorStep, ImageStep1),
+        (DirectorStep, ImageStep2),
+    ]
+
+
+class DirectorRootRotationVersionSkipUptane(Uptane):
+
+    '''Director step 0 has root v1, step 1 has root v2, and it is correctly cross signed,
+       but the version skips the expected value.'''
+
+    class ImageStep(Step):
+
+        TARGETS_KEYS_IDX = [1]
+        SNAPSHOT_KEYS_IDX = [2]
+        TIMESTAMP_KEYS_IDX = [3]
+
+        ROOT_KWARGS = {
+            'root_keys_idx': [0],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        SNAPSHOT_KWARGS = {
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+        }
+
+        TIMESTAMP_KWARGS = {
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+    class DirectorStep1(Step):
+
+        TARGETS_KEYS_IDX = [5]
+
+        ROOT_KWARGS = {
+            'root_keys_idx': [4],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+    class DirectorStep2(Step):
+
+        # Note that aktualizr doesn't actually throw an exception; it just fails.
+        UPDATE_ERROR = 'UnmetThreshold::Root'
+
+        TARGETS_KEYS_IDX = [5]
+
+        ROOT_KWARGS = {
+            'version': 2,
+            'root_keys_idx': [6],
+            'root_sign_keys_idx': [4, 6],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'stated_version': 3,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+    STEPS = [
+        (DirectorStep1, ImageStep),
+        (DirectorStep2, ImageStep),
+    ]
+
+
+class ImageRepoRootRotationVersionSkipUptane(Uptane):
+
+    '''Image repo step 0 has root v1, step 1 has root v2, and it is correctly cross signed,
+       but the version skips the expected value.'''
+
+    class ImageStep1(Step):
+
+        TARGETS_KEYS_IDX = [1]
+        SNAPSHOT_KEYS_IDX = [2]
+        TIMESTAMP_KEYS_IDX = [3]
+
+        ROOT_KWARGS = {
+            'root_keys_idx': [0],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        SNAPSHOT_KWARGS = {
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+        }
+
+        TIMESTAMP_KWARGS = {
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+    class ImageStep2(Step):
+
+        # Note that aktualizr doesn't actually throw an exception; it just fails.
+        UPDATE_ERROR = 'UnmetThreshold::Root'
+
+        TARGETS_KEYS_IDX = [1]
+        SNAPSHOT_KEYS_IDX = [2]
+        TIMESTAMP_KEYS_IDX = [3]
+
+        ROOT_KWARGS = {
+            'version': 2,
+            'root_keys_idx': [6],
+            'root_sign_keys_idx': [0, 6],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+            'stated_version': 3,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        SNAPSHOT_KWARGS = {
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+        }
+
+        TIMESTAMP_KWARGS = {
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+    class DirectorStep(Step):
+
+        TARGETS_KEYS_IDX = [5]
+
+        ROOT_KWARGS = {
+            'root_keys_idx': [4],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+    STEPS = [
+        (DirectorStep, ImageStep1),
+        (DirectorStep, ImageStep2),
+    ]
+
+
 class DirectorBadHwIdUptane(Uptane):
 
     '''The director targets metadata has a bad hardware ID'''


### PR DESCRIPTION
Don't allow fetching a version of the metadata that doesn't exist or shouldn't exist yet in the current step.