### PR TITLE
The second rotation should remove the initial key.

### DIFF
--- a/tuf_vectors/uptane.py
+++ b/tuf_vectors/uptane.py
@@ -4504,7 +4504,7 @@ class DirectorTargetsRoleTypeMismatchUptane(Uptane):
     ]
 
 
-class ImageRepRootRoleTypeMismatchUptane(Uptane):
+class ImageRepoRootRoleTypeMismatchUptane(Uptane):
     """
     The type of role must have an appropriate name in the metadata file.
     ImageRepo role Root: _type = "Root"
@@ -4555,7 +4555,7 @@ class ImageRepRootRoleTypeMismatchUptane(Uptane):
     ]
 
 
-class ImageRepTargetsRoleTypeMismatchUptane(Uptane):
+class ImageRepoTargetsRoleTypeMismatchUptane(Uptane):
     """
     The type of role must have an appropriate name in the metadata file.
     ImageRepo role Targets: _type = "Targets"

--- a/tuf_vectors/uptane.py
+++ b/tuf_vectors/uptane.py
@@ -2328,7 +2328,7 @@ class DirectorRootRotationMultipleUptane(Uptane):
             {
                 'version': 3,
                 'root_keys_idx': [7],
-                'root_sign_keys_idx': [4, 6, 7],
+                'root_sign_keys_idx': [6, 7],
                 'targets_keys_idx': TARGETS_KEYS_IDX,
             },
         ]
@@ -2465,7 +2465,7 @@ class ImageRepoRootRotationMultipleUptane(Uptane):
             {
                 'version': 3,
                 'root_keys_idx': [7],
-                'root_sign_keys_idx': [0, 6, 7],
+                'root_sign_keys_idx': [6, 7],
                 'targets_keys_idx': TARGETS_KEYS_IDX,
                 'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
                 'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,


### PR DESCRIPTION
Of course there's nothing inherently wrong with having v3 signed by all three Root versions, but that isn't a very interesting test. Instead remove the v1 key such that v3 can really only be verified with the v2 Root.

@cajun-rat @mike-sul @heartsucker

We should really move this to the Uptane namespace...