### PR TITLE
Test an update if metadata version is the same while their content have been changed

### DIFF
--- a/tuf_vectors/metadata.py
+++ b/tuf_vectors/metadata.py
@@ -418,6 +418,7 @@ class Snapshot(Metadata):
             delegations: dict,  # role_name -> contents_dict
             snapshot_sign_keys_idx: list = None,
             targets_version: int = None,
+            add_targets_hash_and_length: bool = False,
             **kwargs) -> None:
         super().__init__(is_delegation=False, **kwargs)
         self.role_name = 'snapshot'
@@ -440,6 +441,13 @@ class Snapshot(Metadata):
                 },
             },
         }
+
+        if add_targets_hash_and_length:
+            targets_content = self.cjson(targets).encode('utf-8')
+            signed['meta']['targets.json']['hashes'] = {
+                'sha256': sha256(targets_content, False),
+            }
+            signed['meta']['targets.json']['length'] = len(targets_content)
 
         for (name, meta) in delegations.items():
             if name == SKIPPED_DELEGATION_NAME:

--- a/tuf_vectors/uptane.py
+++ b/tuf_vectors/uptane.py
@@ -3091,6 +3091,124 @@ class ImageRepoRootRotationVersionSkipUptane(Uptane):
     ]
 
 
+class ImageRepoMetadataChangedWhileVersionSameUptane(Uptane):
+
+    '''Image repo step 0 has timestamp, snapshot, and targets v1, step 1 has different metadata than step 0,
+       but, the version is the same. Update should succeed in this case, since the specification does NOT forbid it '''
+
+    class ImageStep1(Step):
+        TARGETS_KEYS_IDX = [1]
+        SNAPSHOT_KEYS_IDX = [2]
+        TIMESTAMP_KEYS_IDX = [3]
+
+        ROOT_KWARGS = {
+            'root_keys_idx': [0],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'targets': lambda hardware_id, ecu_identifier: [
+                Target(name=DEFAULT_TARGET_NAME,
+                       content=DEFAULT_TARGET_CONTENT,
+                       hardware_id=hardware_id,
+                       ecu_identifier=ecu_identifier)
+            ]
+        }
+
+        SNAPSHOT_KWARGS = {
+            'add_targets_hash_and_length': True,
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+        }
+
+        TIMESTAMP_KWARGS = {
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+    class ImageStep2(Step):
+        TARGETS_KEYS_IDX = [1]
+        SNAPSHOT_KEYS_IDX = [2]
+        TIMESTAMP_KEYS_IDX = [3]
+
+        ROOT_KWARGS = {
+            'version': 1,
+            'root_keys_idx': [6],
+            'root_sign_keys_idx': [0, 6],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'targets': lambda hardware_id, ecu_identifier: [
+                Target(name=DEFAULT_TARGET_NAME,
+                       content=DEFAULT_TARGET_CONTENT,
+                       hardware_id=hardware_id,
+                       ecu_identifier=ecu_identifier),
+                Target(name='file01.txt',
+                       content=b'some foobar content',
+                       hardware_id=hardware_id,
+                       ecu_identifier=ecu_identifier)
+
+            ]
+        }
+
+        SNAPSHOT_KWARGS = {
+            'add_targets_hash_and_length': True,
+            'snapshot_keys_idx': SNAPSHOT_KEYS_IDX,
+        }
+
+        TIMESTAMP_KWARGS = {
+            'timestamp_keys_idx': TIMESTAMP_KEYS_IDX,
+        }
+
+    class DirectorStep1(Step):
+        TARGETS_KEYS_IDX = [5]
+
+        ROOT_KWARGS = {
+            'root_keys_idx': [4],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'targets': lambda hardware_id, ecu_identifier: [
+                Target(name=DEFAULT_TARGET_NAME,
+                       content=DEFAULT_TARGET_CONTENT,
+                       hardware_id=hardware_id,
+                       ecu_identifier=ecu_identifier)
+            ]
+        }
+
+    class DirectorStep2(Step):
+        TARGETS_KEYS_IDX = [5]
+
+        ROOT_KWARGS = {
+            'root_keys_idx': [4],
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+        }
+
+        TARGETS_KWARGS = {
+            'version': 2,
+            'targets_keys_idx': TARGETS_KEYS_IDX,
+            'targets': lambda hardware_id, ecu_identifier: [
+                Target(name='file01.txt',
+                       content=b'some foobar content',
+                       hardware_id=hardware_id,
+                       ecu_identifier=ecu_identifier)
+
+                ]
+        }
+
+    STEPS = [
+        (DirectorStep1, ImageStep1),
+        (DirectorStep2, ImageStep2),
+    ]
+
+
 class DirectorBadHwIdUptane(Uptane):
 
     '''The Director Targets metadata has a bad hardware ID'''


### PR DESCRIPTION
Add a test that verify whether aktualizr can perform an update if
targets and corresponding snapshot and timestamp metadata are updated
while their version is the same.
This test is specifically dedicated for the recent fix to the imagerepo
functionality